### PR TITLE
fixed bug in prov_v2 logdet

### DIFF
--- a/flow/bijector_proj_real_nvp_v2.py
+++ b/flow/bijector_proj_real_nvp_v2.py
@@ -160,7 +160,7 @@ class ProjectedScalarAffine(distrax.Bijector):
         flattened_event_n_elements = np.prod(event_shape)
         vectors = vectors.reshape((-1, np.prod(event_shape)))
         scale = scale.flatten()
-        slog_det_in = jnp.eye(flattened_event_n_elements) + vectors.T @ (vectors @ scale[:, None])
+        slog_det_in = jnp.eye(flattened_event_n_elements) + vectors.T @ (vectors @ (scale[:, None] ** -1))
         s, log_det2 = jnp.linalg.slogdet(slog_det_in)
         return jnp.sum(log_scale, axis=-1) + log_det2
 
@@ -260,7 +260,7 @@ def make_se_equivariant_split_coupling_with_projection(layer_number, dim, swap,
                                                        n_vectors: Optional[int] = None,
                                                        ):
     assert dim in (2, 3)  # Currently just written for 2D and 3D
-    n_vectors = n_vectors if n_vectors else 12
+    n_vectors = n_vectors if n_vectors else 12  # should not hardcode this and make it non-optional
     n_invariant_params = dim*2 + dim*n_vectors
 
     def bijector_fn(params):


### PR DESCRIPTION
I did dw4 runs with these settings:
```
  cfg.training.lr = 1e-4
  cfg.flow.egnn.tanh = False
  cfg.flow.act_norm = True
  cfg.target.aug_global_centering = False
  cfg.flow.egnn.mlp_units = (8,)
  cfg.flow.kwargs.proj_v2.mlp_function_units = (16,)
  cfg.flow.kwargs.proj_v2.global_frame = False
  cfg.flow.kwargs.proj_v2.process_flow_params_jointly = False
  cfg.flow.kwargs.proj_v2.condition_on_x_proj = True
  cfg.flow.transformer.mlp_units = (16,)
  cfg.flow.transformer.n_layers = 2
  cfg.flow.n_layers = 2
  cfg.training.batch_size = 128
  cfg.training.n_epoch = 1000
  cfg.training.save = False
  cfg.training.n_plots = 6
  cfg.training.plot_batch_size = 1034
  cfg.training.K_marginal_log_lik = 5
  cfg.logger = DictConfig({"list_logger": None})
```
and alternated between
```
  cfg.flow.type = [ 'proj', ]
  cfg.flow.type = [ 'proj_v2']
  cfg.flow.type = [ 'proj', 'proj_v2'] (edited)
 ```

Results:
**marginal LL**
proj: -4
proj_v2: -9
mix -2.5 

