### PR TITLE
fix: ignore nan optimizer bug

### DIFF
--- a/examples/config/aldp.yaml
+++ b/examples/config/aldp.yaml
@@ -23,7 +23,6 @@ flow:
     aux:
       conditioned_on_x: ${target.aux.conditioned_on_x}
       scale_init: 1.0
-      trainable_augmented_scale: true
   dim: 3
   nodes: 22
   n_layers: 8

--- a/examples/config/dw4.yaml
+++ b/examples/config/dw4.yaml
@@ -19,7 +19,6 @@ flow:
     aux:
       conditioned_on_x: ${target.aux.conditioned_on_x}
       scale_init: 1.0
-      trainable_augmented_scale: true
   dim: 2
   nodes: 4
   n_aug: 5

--- a/examples/config/dw4_fab.yaml
+++ b/examples/config/dw4_fab.yaml
@@ -45,7 +45,6 @@ flow:
     aux:
       conditioned_on_x: ${target.aux.conditioned_on_x}
       scale_init: 1.0
-      trainable_augmented_scale: true
   dim: 2
   nodes: 4
   n_aug: 1

--- a/examples/config/lj13.yaml
+++ b/examples/config/lj13.yaml
@@ -18,7 +18,6 @@ flow:
     aux:
       conditioned_on_x: ${target.aux.conditioned_on_x}
       scale_init: 1.0
-      trainable_augmented_scale: true
   dim: 3
   nodes: 13
   n_layers: 8

--- a/examples/config/lj13_fab.yaml
+++ b/examples/config/lj13_fab.yaml
@@ -45,7 +45,6 @@ flow:
     aux:
       conditioned_on_x: ${target.aux.conditioned_on_x}
       scale_init: 1.0
-      trainable_augmented_scale: true
   dim: 3
   nodes: 13
   n_layers: 8

--- a/examples/config/qm9.yaml
+++ b/examples/config/qm9.yaml
@@ -18,7 +18,6 @@ flow:
     aux:
       conditioned_on_x: ${target.aux.conditioned_on_x}
       scale_init: 1.0
-      trainable_augmented_scale: true
   dim: 3
   nodes: 19
   n_layers: 8

--- a/flow/build_flow.py
+++ b/flow/build_flow.py
@@ -74,7 +74,8 @@ def create_flow_recipe(config: FlowDistConfig) -> AugmentedFlowRecipe:
             n_aux=config.n_aug,
             x_dist=x_dist,
             augmented_scale_init=config.base.aug.scale_init,
-            augmented_conditioned=config.base.aug.conditioned_on_x
+            augmented_conditioned=config.base.aug.conditioned_on_x,
+            trainable_augmented_scale=config.base.aug.trainable_augmented_scale
         )
         return base
 

--- a/utils/optimize.py
+++ b/utils/optimize.py
@@ -29,8 +29,9 @@ def dynamic_update_ignore_and_grad_norm_clip(optimizer: optax.GradientTransforma
 
     def init(params: chex.ArrayTree) -> IgnoreNanOptState:
         opt_state = optimizer.init(params)
-        grad_norms = jnp.zeros(window_length)
-        grad_norms = grad_norms.at[0:3].set(1e30)
+        grad_norms = jnp.ones(window_length)*float('nan')
+        # After initialisation, for first third of window length take every gradient step.
+        grad_norms = grad_norms.at[0:int(window_length*2/3)].set(1e30)
         return IgnoreNanOptState(opt_state=opt_state, grad_norms=grad_norms)
 
     def update(grad: chex.ArrayTree, opt_state: IgnoreNanOptState, params: chex.ArrayTree) ->\


### PR DESCRIPTION
- fix bug in ignore nan optimizer where we were not taking any gradient steps for the first half of the window, due to `median_grad_norm` being set to 0. 
- Ensure exception gets hit if we try to train the augmented scale