### PR TITLE
feat: made aldp target compilable and differentiable

### DIFF
--- a/eacf/targets/target_energy/aldp_test.py
+++ b/eacf/targets/target_energy/aldp_test.py
@@ -1,9 +1,9 @@
 from pathlib import Path
+import jax
 import jax.numpy as jnp
 
 from eacf.targets.data import load_aldp
 from eacf.targets.target_energy.aldp import get_log_prob_fn, get_multi_proc_log_prob_fn
-from time import time
 
 
 def test_aldp_log_prob():
@@ -17,9 +17,14 @@ def test_aldp_log_prob():
     # Compute log prob
     log_prob = log_prob_fn(aldp_data.positions)
 
+    # Test vmap and jit
+    log_prob_vmap_jit = jax.jit(jax.vmap(log_prob_fn))
+    log_prob_ = log_prob_vmap_jit(aldp_data.positions)
+
     # Check log prob
     assert jnp.shape(log_prob) == (100,)
     assert jnp.all(jnp.isfinite(log_prob))
+    assert jnp.allclose(log_prob, log_prob_)
 
 
 def test_aldp_multi_proc_log_prob():
@@ -36,12 +41,17 @@ def test_aldp_multi_proc_log_prob():
     log_prob_mp = log_prob_mp_fn(aldp_data.positions)
     log_prob = log_prob_fn(aldp_data.positions)
 
+    # Test vmap and jit
+    log_prob_vmap_jit = jax.jit(jax.vmap(log_prob_mp_fn))
+    log_prob_ = log_prob_vmap_jit(aldp_data.positions)
+
     # Check log prob
     assert jnp.shape(log_prob_mp) == (n_data,)
     assert jnp.shape(log_prob) == (n_data,)
     assert jnp.all(jnp.isfinite(log_prob_mp))
     assert jnp.all(jnp.isfinite(log_prob))
     assert jnp.allclose(log_prob_mp, log_prob)
+    assert jnp.allclose(log_prob_mp, log_prob_)
 
 
 if __name__ == "__main__":

--- a/eacf/targets/target_energy/aldp_test.py
+++ b/eacf/targets/target_energy/aldp_test.py
@@ -21,10 +21,14 @@ def test_aldp_log_prob():
     log_prob_vmap_jit = jax.jit(jax.vmap(log_prob_fn))
     log_prob_ = log_prob_vmap_jit(aldp_data.positions)
 
+    # Compute gradient
+    log_prob_grad = jax.vmap(jax.grad(log_prob_fn))(aldp_data.positions)
+
     # Check log prob
     assert jnp.shape(log_prob) == (100,)
     assert jnp.all(jnp.isfinite(log_prob))
     assert jnp.allclose(log_prob, log_prob_)
+    assert log_prob_grad.shape == aldp_data.positions.shape
 
 
 def test_aldp_multi_proc_log_prob():
@@ -45,6 +49,9 @@ def test_aldp_multi_proc_log_prob():
     log_prob_vmap_jit = jax.jit(jax.vmap(log_prob_mp_fn))
     log_prob_ = log_prob_vmap_jit(aldp_data.positions)
 
+    # Compute gradient
+    log_prob_grad = jax.vmap(jax.grad(log_prob_fn))(aldp_data.positions)
+
     # Check log prob
     assert jnp.shape(log_prob_mp) == (n_data,)
     assert jnp.shape(log_prob) == (n_data,)
@@ -52,6 +59,7 @@ def test_aldp_multi_proc_log_prob():
     assert jnp.all(jnp.isfinite(log_prob))
     assert jnp.allclose(log_prob_mp, log_prob)
     assert jnp.allclose(log_prob_mp, log_prob_)
+    assert log_prob_grad.shape == aldp_data.positions.shape
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Now, `jit`, `vmap`, `pmap`, etc. can be applied to the target distribution of aldp
* Furthermore, gradient computation is possible
* Energy and forces are still computed on a single thread on the CPU